### PR TITLE
Removed method because of retired endpoint

### DIFF
--- a/lib/instagram/client/media.rb
+++ b/lib/instagram/client/media.rb
@@ -21,25 +21,6 @@ module Instagram
         response
       end
 
-      # Returns extended information of a given media item
-      #
-      # @overload media_shortcode(shortcode)
-      #   @param shortcode [String] An Instagram media item shortcode
-      #   @return [Hashie::Mash] The requested media item.
-      #   @example Return extended information for media item with shortcode 'D'
-      #     Instagram.media_shortcode('D')
-      # @format none
-      # @authenticated false unless requesting media from a protected user
-      #
-      #   If getting this data of a protected user, you must authenticate (and be allowed to see that user).
-      # @rate_limited true
-      # @see http://instagram.com/developer/endpoints/media/#get_media_by_shortcode
-      def media_shortcode(*args)
-        shortcode = args.first
-        response = get("media/shortcode/#{shortcode}", {}, false, false, true)
-        response
-      end
-
       # Returns a list of the overall most popular media
       #
       # @overload media_popular(options={})

--- a/spec/instagram/client/media_spec.rb
+++ b/spec/instagram/client/media_spec.rb
@@ -27,26 +27,6 @@ describe Instagram::Client do
         end
       end
 
-      describe ".media_shortcode" do
-        before do
-          stub_get("media/shortcode/BG9It")
-            .with(query: { access_token: @client.access_token })
-            .to_return(body: fixture("media_shortcode.#{format}"), headers: { content_type: "application/#{format}; charset=utf-8" })
-        end
-
-        it "should get the correct resource" do
-          @client.media_shortcode("BG9It")
-          expect(a_get("media/shortcode/BG9It")
-            .with(query: { access_token: @client.access_token }))
-            .to have_been_made
-        end
-
-        it "should return extended information of a given media item" do
-          media = @client.media_shortcode("BG9It")
-          expect(media.user.username).to eq("mikeyk")
-        end
-      end
-
       describe ".media_popular" do
         before do
           stub_get("media/popular.#{format}")


### PR DESCRIPTION
Instagram retired this endpoint https://api.instagram.com/v1/media/shortcode/Bg6m_qIlPlf